### PR TITLE
Added error flag in multiplex constructor opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function Plex (opts) {
     if (!opts) opts = {};
     Duplex.call(this);
     
-    this._mdm = multiplex({ maxDepth: opts.maxDepth });
+    this._mdm = multiplex({ maxDepth: opts.maxDepth, error: true });
     
     (function () {
         var errored = false, ended = false;


### PR DESCRIPTION
Hi James,

We are starting to see intermittent errors coming from the multiplex module when dataplex is under heavy load. I am not sure what causes the problem as the error comes up at seemingly random times, but essentially one of the sub-streams of multiplex seems to be throwing an error which is then not caught. The stack trace looks something like:

events.js:72
throw er; // Unhandled 'error' event
^
Error: type":"create","key":"34f5d66d-264
at createOrPush (/usr/share/DateraContainer/node-cli-0.7.0.124-bb1fe3c.chroot/src/node-api/mystral/mystral-client/node_modules/dataplex/node_modules/multiplex/index.js:88:57)
at decode (/usr/share/DateraContainer/node-cli-0.7.0.124-bb1fe3c.chroot/src/node-api/mystral/mystral-client/node_modules/dataplex/node_modules/multiplex/index.js:69:5)
at decode (/usr/share/DateraContainer/node-cli-0.7.0.124-bb1fe3c.chroot/src/node-api/mystral/mystral-client/node_modules/dataplex/node_modules/multiplex/index.js:73:9)
at decode (/usr/share/DateraContainer/node-cli-0.7.0.124-bb1fe3c.chroot/src/node-api/mystral/mystral-client/node_modules/dataplex/node_modules/multiplex/index.js:73:9)
at decode (/usr/share/DateraContainer/node-cli-0.7.0.124-bb1fe3c.chroot/src/node-api/mystral/mystral-client/node_modules/dataplex/node_modules/multiplex/index.js:73:9)
at Transform.decode [as _transform] (/usr/share/DateraContainer/node-cli-0.7.0.124-bb1fe3c.chroot/src/node-api/mystral/mystral-client/node_modules/dataplex/node_modules/multiplex/index.js:73:9)
at Transform._read (/usr/share/DateraContainer/node-cli-0.7.0.124-bb1fe3c.chroot/src/node-api/mystral/mystral-client/node_modules/dataplex/node_modules/multiplex/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
at Transform._write (/usr/share/DateraContainer/node-cli-0.7.0.124-bb1fe3c.chroot/src/node-api/mystral/mystral-client/node_modules/dataplex/node_modules/multiplex/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
at doWrite (/usr/share/DateraContainer/node-cli-0.7.0.124-bb1fe3c.chroot/src/node-api/mystral/mystral-client/node_modules/dataplex/node_modules/multiplex/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
at writeOrBuffer (/usr/share/DateraContainer/node-cli-0.7.0.124-bb1fe3c.chroot/src/node-api/mystral/mystral-client/node_modules/dataplex/node_modules/multiplex/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)\

It is odd because the content of the error is part of a data chunk, as you can see in the first line of the backtrace.

In any case, adding "error: true" to the constructor args to multiplex from within dataplex seems to have solved the problem. I can't say I have a full understanding of what's going on there, so if you have time to investigate further and see if this is the right solution that would be much appreciated.

Thanks!