### PR TITLE
Adding destroy to finish event

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,9 @@ function Plex (opts) {
         Object.keys(self._localStreams).forEach(function (key) {
             var s = self._localStreams[key];
             if (s && typeof s.emit === 'function') s.emit('_close');
+            if (s.destroy) {
+                s.destroy();
+            }
         });
     });
 }


### PR DESCRIPTION
Calling destroy on local streams when the 'finish' event is fired. The destroy function is being used whenever the client (browser) navigates, hence for consistency, destroy needs to be called when the connection terminates prematurely.